### PR TITLE
Change free() to close()

### DIFF
--- a/navx/ahrs.py
+++ b/navx/ahrs.py
@@ -185,7 +185,7 @@ class AHRS(wpilib.SensorBase):
         wpilib.Resource._add_global_resource(self)
     
     
-    def free(self):
+    def close(self):
         self.io.stop()
         try:
             self.ioThread.join(timeout=5)


### PR DESCRIPTION
- Because it inherits from SensorBase, the backwards compat doesn't kick in